### PR TITLE
I've found an issue at "tunnel.on('error', ...".

### DIFF
--- a/tasks/ssh-multi-exec.js
+++ b/tasks/ssh-multi-exec.js
@@ -115,7 +115,7 @@ var init = function() {
         });
 
         tunnel.on('error', function(err) {
-            writeBufferedLog(shellPrefix, 'Connection error: ' + err.red);
+            writeBufferedLog(shellPrefix, 'Connection error: ' + err.message.red, function(msg) {return msg;});
             flushBufferedLog(shellPrefix);
             done();
         });


### PR DESCRIPTION
Hi.
118 line, writeBufferedLog's third parameter is missing.
When call "writeBufferedLog", third argument what "fn" is must passed.
Otherwise it occur "Fatal error: undefined is not a function".